### PR TITLE
Add clang-format and clang-tidy ruleset

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language: Cpp
+BasedOnStyle: Google
+PointerAlignment: Right

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+Checks: "
+  -*,
+  google-*,
+  bugprone-*,
+  readability-*,
+  performance-*,
+  portability-*
+"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,3 +6,4 @@ Checks: "
   performance-*,
   portability-*
 "
+WarningsAsErrors: '*'

--- a/clang-format-lint-all.sh
+++ b/clang-format-lint-all.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for item in `find . -not -path './build/*' -name '*.c' -or -name '*.h' -or -name '*.h.in'`; do
+  clang-tidy ${item}
+  clang-format ${item} -i
+done


### PR DESCRIPTION
- **What**: Add 2 rulesets, .clang-tidy and .clang-format. Also add a convenience script to lint and format all source files (clang-format-lint-all.sh)

- **Why**: Better let the compiler complain than some unexpected behavior that takes hours to track down. Also, an agreeable code format looks more consistent on everyone's machines.

- **How**: 
  - Make sure you have created a symlink to build/compile_commands.json after running `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..` in your newly created `build` directory.
  - Make sure to have clang-tidy and clang-format installed (if you follow the dev-env documentation, you should have).
  - For now, every time you would like to commit, run the convenience script beforehand.

- **Note** :eyes:
  - I will test this functionality on Windows soon. But I expect it to work well, so long as you have your environment set up accordingly to the dev-env doc.
